### PR TITLE
Various BTE expansion fixes

### DIFF
--- a/shepherd/query_expansion/bte/expansion.py
+++ b/shepherd/query_expansion/bte/expansion.py
@@ -128,11 +128,11 @@ def fill_templates(
             template = Query.parse_obj(json.load(file))
         if subject_curie is not None:
             cast(QueryGraph, template.message.query_graph).nodes[
-                "creativeQuerySubject"
+                "sn"
             ].ids = HashableSequence(__root__=[subject_curie])
         if object_curie is not None:
             cast(QueryGraph, template.message.query_graph).nodes[
-                "creativeQueryObject"
+                "on"
             ].ids = HashableSequence(__root__=[object_curie])
         filled_templates.append(template)
         if query_body.log_level is not None:

--- a/shepherd/query_expansion/bte/expansion.py
+++ b/shepherd/query_expansion/bte/expansion.py
@@ -161,7 +161,16 @@ def expand_bte_query(query_dict: dict[str, Any]) -> list[Any]:
         subject_type, object_type, predicate, qualifiers
     )
 
-    queries = fill_templates(
+    templates = fill_templates(
         matched_template_paths, query_body, subject_curie, object_curie
     )
-    return [query.dict() for query in queries]
+
+    final_templates = []
+
+    for template in templates:
+        template = template.dict()
+        del template["message"]["knowledge_graph"]
+        template["workflow"] = [{"id": "lookup"}]
+        final_templates.append(template)
+
+    return final_templates

--- a/shepherd/query_expansion/bte/expansion.py
+++ b/shepherd/query_expansion/bte/expansion.py
@@ -136,13 +136,14 @@ def fill_templates(
     return filled_templates
 
 
-def expand_bte_query(query_body: Query) -> list[Any]:
+def expand_bte_query(query_dict: dict[str, Any]) -> list[Any]:
     """Expand a given query into the appropriate templates."""
     # Contract:
     # 1. there is a single edge in the query graph
     # 2. The edge is marked inferred.
     # 3. Either the source or the target has IDs, but not both.
     # 4. The number of ids on the query node is 1.
+    query_body = Query.parse_obj(query_dict)
 
     query_graph = query_body.message.query_graph
     if query_graph is None:
@@ -155,4 +156,5 @@ def expand_bte_query(query_body: Query) -> list[Any]:
         subject_type, object_type, predicate, qualifiers
     )
 
-    return fill_templates(matched_template_paths, subject_curie, object_curie)
+    queries = fill_templates(matched_template_paths, subject_curie, object_curie)
+    return [query.dict() for query in queries]

--- a/shepherd/query_expansion/bte/expansion.py
+++ b/shepherd/query_expansion/bte/expansion.py
@@ -2,21 +2,57 @@
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional, cast
+from pydantic import BaseModel, parse_obj_as
+from reasoner_pydantic import (
+    CURIE,
+    BiolinkEntity,
+    BiolinkPredicate,
+    BiolinkQualifier,
+    HashableSequence,
+    QEdge,
+    Query,
+    QueryGraph,
+)
 
 
-def get_params(query_graph) -> tuple[str, str, str, str, str, dict[str, str]]:
-    edge = next(iter(query_graph["edges"].values()))
-    q_subject = query_graph["nodes"][edge["subject"]]
-    subject_type = q_subject["categories"][0].removeprefix("biolink:")
-    q_object = query_graph["nodes"][edge["object"]]
-    object_type = q_object["categories"][0].removeprefix("biolink:")
-    predicate = edge["predicates"][0].removeprefix("biolink:")
-    subject_curie = q_subject.get("ids", [None])[0]
-    object_curie = q_object.get("ids", [None])[0]
-    qualifiers = {}
+class TemplateGroup(BaseModel):
+    """A group of templates to be matched by given criteria."""
 
-    qualifier_constraints = edge.get("qualifier_constraints")
+    name: str
+    subject: list[str]
+    predicate: list[str]
+    object: list[str]
+    templates: list[str]
+    qualifiers: Optional[dict[str, str]]
+
+
+def get_params(
+    query_graph: QueryGraph,
+) -> tuple[
+    Optional[BiolinkEntity],
+    Optional[CURIE],
+    Optional[BiolinkEntity],
+    Optional[CURIE],
+    Optional[BiolinkPredicate],
+    dict[BiolinkQualifier, str],
+]:
+    """Obtain some important parameters from the query graph."""
+    edge = cast(QEdge, next(iter(query_graph.edges.values())))
+
+    q_subject = query_graph.nodes[edge.subject]
+    subject_type = next(iter(q_subject.categories or []), None)
+
+    q_object = query_graph.nodes[edge.object]
+    object_type = next(iter(q_object.categories or []), None)
+
+    predicate = next(iter(edge.predicates or []), None)
+
+    subject_curie = next(iter(q_subject.ids or []), None)
+    object_curie = next(iter(q_object.ids or []), None)
+    qualifiers: dict[BiolinkQualifier, str] = {}
+
+    qualifier_constraints = edge.qualifier_constraints
     if qualifier_constraints is not None and len(qualifier_constraints) > 0:
         qualifiers = {
             qualifier["qualifier_type_id"]: qualifier["qualifier_value"]
@@ -33,61 +69,74 @@ def get_params(query_graph) -> tuple[str, str, str, str, str, dict[str, str]]:
     )
 
 
-def match_templates(subject_type, object_type, predicate, qualifiers) -> list[Path]:
+def match_templates(
+    subject_type: Optional[BiolinkEntity],
+    object_type: Optional[BiolinkEntity],
+    predicate: Optional[BiolinkPredicate],
+    qualifiers: dict[BiolinkQualifier, str],
+) -> list[Path]:
+    """Match a given set of parameters to a number of templates."""
 
     # TODO: expand subject/object types by descending the biolink hierarchy
-    subject_types, object_types, predicates = {subject_type}, {object_type}, {predicate}
+    subject_types: set[str] = set()
+    object_types: set[str] = set()
+    predicates: set[str] = set()
+    if subject_type is not None:
+        subject_types.add(subject_type.removeprefix("biolink:"))
+    if object_type is not None:
+        object_types.add(object_type.removeprefix("biolink:"))
+    if predicate is not None:
+        predicates.add(predicate.removeprefix("biolink:"))
 
     with open(Path(__file__).parent / "templateGroups.json", "r") as file:
-        templateGroups = json.load(file)
+        templateGroups = parse_obj_as(list[TemplateGroup], json.load(file))
 
     template_paths = {
         path.name: path
         for path in (Path(__file__).parent / "templates").rglob("*.json")
     }
 
-    # TODO: strict typing
-    matched_paths = set()
+    matched_paths: set[Path] = set()
     for group in templateGroups:
-        conditions = []
-        conditions.append(len(subject_types.intersection(group["subject"])) > 0)
-        conditions.append(len(object_types.intersection(group["object"])) > 0)
-        conditions.append(len(predicates.intersection(group["predicate"])) > 0)
+        conditions: list[bool] = []
+        conditions.append(len(subject_types.intersection(group.subject)) > 0)
+        conditions.append(len(object_types.intersection(group.object)) > 0)
+        conditions.append(len(predicates.intersection(group.predicate)) > 0)
         conditions.append(  # Qualifiers (if they exist) are satisfied
             all(
-                group.get("qualifiers", {}).get(qualifier_type, False) == value
+                (group.qualifiers or {}).get(qualifier_type, False) == value
                 for qualifier_type, value in qualifiers.items()
             )
         )
 
         if all(conditions):
-            for template in group["templates"]:
+            for template in group.templates:
                 matched_paths.add(template_paths[template])
 
     return list(matched_paths)
 
 
 def fill_templates(
-    paths: list[Path], subject_curie, object_curie
-) -> list[dict[str, Any]]:
-    filled_templates = []
+    paths: list[Path], subject_curie: Optional[CURIE], object_curie: Optional[CURIE]
+) -> list[Query]:
+    filled_templates: list[Query] = []
     for path in paths:
         with open(path, "r") as file:
-            template = json.load(file)
+            template = Query.parse_obj(json.load(file))
         if subject_curie is not None:
-            template["message"]["query_graph"]["nodes"]["creativeQuerySubject"][
-                "ids"
-            ] = [subject_curie]
+            cast(QueryGraph, template.message.query_graph).nodes[
+                "creativeQuerySubject"
+            ].ids = HashableSequence(__root__=[subject_curie])
         if object_curie is not None:
-            template["message"]["query_graph"]["nodes"]["creativeQueryObject"][
-                "ids"
-            ] = [object_curie]
+            cast(QueryGraph, template.message.query_graph).nodes[
+                "creativeQueryObject"
+            ].ids = HashableSequence(__root__=[object_curie])
         filled_templates.append(template)
 
     return filled_templates
 
 
-def expand_bte_query(query_body):
+def expand_bte_query(query_body: Query) -> list[Any]:
     """Expand a given query into the appropriate templates."""
     # Contract:
     # 1. there is a single edge in the query graph
@@ -95,7 +144,9 @@ def expand_bte_query(query_body):
     # 3. Either the source or the target has IDs, but not both.
     # 4. The number of ids on the query node is 1.
 
-    query_graph = query_body["message"]["query_graph"]
+    query_graph = query_body.message.query_graph
+    if query_graph is None:
+        return []
     subject_type, subject_curie, object_type, object_curie, predicate, qualifiers = (
         get_params(query_graph)
     )

--- a/shepherd/query_expansion/bte/expansion.py
+++ b/shepherd/query_expansion/bte/expansion.py
@@ -117,7 +117,10 @@ def match_templates(
 
 
 def fill_templates(
-    paths: list[Path], subject_curie: Optional[CURIE], object_curie: Optional[CURIE]
+    paths: list[Path],
+    query_body: Query,
+    subject_curie: Optional[CURIE],
+    object_curie: Optional[CURIE],
 ) -> list[Query]:
     filled_templates: list[Query] = []
     for path in paths:
@@ -132,6 +135,8 @@ def fill_templates(
                 "creativeQueryObject"
             ].ids = HashableSequence(__root__=[object_curie])
         filled_templates.append(template)
+        if query_body.log_level is not None:
+            template.log_level = query_body.log_level
 
     return filled_templates
 
@@ -156,5 +161,7 @@ def expand_bte_query(query_dict: dict[str, Any]) -> list[Any]:
         subject_type, object_type, predicate, qualifiers
     )
 
-    queries = fill_templates(matched_template_paths, subject_curie, object_curie)
+    queries = fill_templates(
+        matched_template_paths, query_body, subject_curie, object_curie
+    )
     return [query.dict() for query in queries]

--- a/shepherd/query_expansion/bte/implementation_notes.md
+++ b/shepherd/query_expansion/bte/implementation_notes.md
@@ -1,5 +1,0 @@
-- The input/output types are not specified, but should be
-  - Output should just be pure query graphs, no extra workflow/etc information?
-- Have the input nodes been resolved?
-- Is there a biolink module for hierarchy traversal?
-- Is there a standardized mechanism/return value to signal that the query could not be expanded?

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-DecreaseAnotherGeneThatUpregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-DecreaseAnotherGeneThatUpregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-IncreaseAnotherGeneThatDownregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-IncreaseAnotherGeneThatDownregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-decreasesGene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-decreasesGene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-negatively_correlated-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-negatively_correlated-Gene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:negatively_correlated_with"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-physically_interacts-GeneThatDownregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-physically_interacts-GeneThatDownregs-Gene.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:physically_interacts_with"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-DecreaseAnotherGeneThatDownregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-DecreaseAnotherGeneThatDownregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-IncreaseAnotherGeneThatUpregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-IncreaseAnotherGeneThatUpregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-increasesGene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-increasesGene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-physically_interacts-GeneThatUpregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-physically_interacts-GeneThatUpregs-Gene.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:physically_interacts_with"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-positively_correlated-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-positively_correlated-Gene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:positively_correlated_with"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Chem-physically_interacts-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-physically_interacts-Gene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:physically_interacts_with"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-decreaseGeneWithFunctionGainIn-Disease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-decreaseGeneWithFunctionGainIn-Disease.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "qualifier_constraints": [
                         {
@@ -34,7 +34,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-increaseGeneWithFunctionLossIn-Disease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-increaseGeneWithFunctionLossIn-Disease.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "qualifier_constraints": [
                         {
@@ -34,7 +34,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-interacts,correlated,associated-Gene-biomarker,associated_condition-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-interacts,correlated,associated-Gene-biomarker,associated_condition-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:physically_interacts_with", "biolink:correlated_with", "biolink:associated_with"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": [
                         "biolink:gene_associated_with_condition",
                         "biolink:biomarker_for"

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-biomarker,associated_condition-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-biomarker,associated_condition-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:regulates", "biolink:affects"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": [
                         "biolink:gene_associated_with_condition",
                         "biolink:biomarker_for"

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-cause,contribute,affects-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-cause,contribute,affects-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:regulates", "biolink:affects"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": [
                         "biolink:affects",
                         "biolink:causes",

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-causes,part-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-causes,part-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:treats"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "creativeQueryObject",
+                    "object": "on",
                     "predicates": [
                         "biolink:part_of", 
                         "biolink:causes"

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-similar,part-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-similar,part-DoP.json
@@ -2,25 +2,25 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:treats"]
                 },
                 "eB": {
-                    "subject": "creativeQueryObject",
+                    "subject": "on",
                     "object": "nA",
                     "predicates": [
                         "biolink:similar_to", 

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:treats_or_applied_or_studied_to_treat"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-PhenoOfDisease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-PhenoOfDisease.json
@@ -2,25 +2,25 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:PhenotypicFeature"],
                     "is_set": true
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
+                    "subject": "sn",
                     "object": "nA",
                     "predicates": ["biolink:treats_or_applied_or_studied_to_treat"]
                 },
                 "eB": {
-                    "subject": "creativeQueryObject",
+                    "subject": "on",
                     "object": "nA",
                     "predicates": ["biolink:has_phenotype"]
                 }

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/ChemDecreasesLikelihood-Disease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/ChemDecreasesLikelihood-Disease.json
@@ -2,18 +2,18 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":
                     ["ChemicalEntity"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/NonChem-treats-DoP.json
+++ b/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/NonChem-treats-DoP.json
@@ -2,18 +2,18 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":
                     ["biolink:Procedure", "biolink:Treatment", "biolink:ClinicalIntervention"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:treats"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Procedure-decreasesLikelihood-Disease.json
+++ b/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Procedure-decreasesLikelihood-Disease.json
@@ -2,18 +2,18 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":
                     ["Procedure"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Treatment-related_to-DoP.json
+++ b/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Treatment-related_to-DoP.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:Treatment"]
                 },
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQuerySubject",
-                    "object": "creativeQueryObject",
+                    "subject": "sn",
+                    "object": "on",
                     "predicates": ["biolink:related_to"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/less-promising/m3-Disease-SeqVar-Gene-Chem.json
+++ b/shepherd/query_expansion/bte/templates/less-promising/m3-Disease-SeqVar-Gene-Chem.json
@@ -2,7 +2,7 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Disease"]
                },
                 "nA": {
@@ -13,13 +13,13 @@
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQueryObject",
+                    "subject": "on",
                     "object": "nA"
                 },
                 "eB": {
@@ -28,7 +28,7 @@
                 },
                 "eC": {
                     "subject": "nB",
-                    "object": "creativeQuerySubject",
+                    "object": "sn",
                     "predicates": ["biolink:regulated_by", "biolink:affected_by"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/less-promising/m5-Disease-Pheno-Gene-Chem.json
+++ b/shepherd/query_expansion/bte/templates/less-promising/m5-Disease-Pheno-Gene-Chem.json
@@ -2,7 +2,7 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Disease"]
                },
                 "nA": {
@@ -13,13 +13,13 @@
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQueryObject",
+                    "subject": "on",
                     "object": "nA",
                     "predicates": ["biolink:has_phenotype"]
                 },
@@ -30,7 +30,7 @@
                 },
                 "eC": {
                     "subject": "nB",
-                    "object": "creativeQuerySubject",
+                    "object": "sn",
                     "predicates": ["biolink:regulated_by", "biolink:affected_by"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/less-promising/m6-Disease-Gene-Gene-Chem.json
+++ b/shepherd/query_expansion/bte/templates/less-promising/m6-Disease-Gene-Gene-Chem.json
@@ -2,7 +2,7 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "creativeQueryObject": {
+                "on": {
                     "categories":["biolink:Disease"]
                },
                 "nA": {
@@ -13,13 +13,13 @@
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "creativeQuerySubject": {
+                "sn": {
                     "categories":["biolink:ChemicalEntity"]
                 }
             },
             "edges": {
                 "eA": {
-                    "subject": "creativeQueryObject",
+                    "subject": "on",
                     "object": "nA",
                     "predicates": ["biolink:caused_by"]
                 },
@@ -30,7 +30,7 @@
                 },
                 "eC": {
                     "subject": "nB",
-                    "object": "creativeQuerySubject",
+                    "object": "sn",
                     "predicates": ["biolink:regulated_by", "biolink:affected_by"]
                 }
             }

--- a/shepherd/server.py
+++ b/shepherd/server.py
@@ -61,10 +61,11 @@ async def query(
 ) -> ReasonerResponse:
     """Handle synchronous TRAPI queries."""
     # expand query to multiple subqueries, options
-    queries, options = await expand_query(query.dict(), {"target": target})
+    query_dict = query.dict()
+    queries, options = await expand_query(query_dict, {"target": target})
     print(json.dumps(queries))
     # save query to db
-    query_id, conn, pool = await add_query(query, len(queries))
+    query_id, conn, pool = await add_query(query_dict, len(queries))
     # retrieve answers
     await retrieve(query_id, queries, options)
     # poll the db for doneness?

--- a/shepherd/server.py
+++ b/shepherd/server.py
@@ -60,9 +60,8 @@ async def query(
     query: Query,
 ) -> ReasonerResponse:
     """Handle synchronous TRAPI queries."""
-    query = query.dict()
     # expand query to multiple subqueries, options
-    queries, options = await expand_query(query, {"target": target})
+    queries, options = await expand_query(query.dict(), {"target": target})
     print(json.dumps(queries))
     # save query to db
     query_id, conn, pool = await add_query(query, len(queries))


### PR DESCRIPTION
BTE expansion now uses reasoner-pydantic.

Query expansion router now receives type `Query` and converts any expanded queries to type `dict` after the fact to avoid serializability problems.

We should decide if all team modules must work in reasoner-pydantic types, or if they're allowed to use either reasoner-pydantic or plain dict.