### PR TITLE
Add example expansion/scoring modules

### DIFF
--- a/shepherd/query_expansion/example/expansion.py
+++ b/shepherd/query_expansion/example/expansion.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+
+# function can be async or not
+async def expand_example_query(query_body: dict[str, Any]) -> list[Any]:
+    # query_body has already been validated to meet reasoner-pydantic's Query.
+    # that is, a standard TRAPI query.
+
+    # If you're interested in using reasoner-pydantic for stricter static typing,
+    # see the indented block below. Otherwise, skip to the bottom.
+
+    #     You can convert back to a Query:
+
+    #     import Query from reasoner_pydantic
+    #     query = Query.parse_obj(query_body)
+
+    #     Then, when you have an expanded query still in reasoner-pydantic type,
+    #     you can convert it back:
+
+    #     return [expanded_query_1.dict()]
+
+    # Query expansion must return a list of valid TRAPI queries.
+    # If no expansion could be done, an empty list may be returned.
+    # Let's just turn the given query into a lookup for now:
+    q_edge = next(iter(query_body["message"]["query_graph"]["edges"]))
+    q_edge.pop('knowledge_type', None)
+    return [query_body]

--- a/shepherd/query_expansion/query_expansion.py
+++ b/shepherd/query_expansion/query_expansion.py
@@ -12,7 +12,6 @@ async def expand_query(
 ) -> tuple[List[Any], Dict[str, Any]]:
     """Get expanded queries."""
     queries = []
-    concurrency = 1
     target = options.get("target")
     concurrency = 1_000_000
     match target:

--- a/shepherd/query_expansion/query_expansion.py
+++ b/shepherd/query_expansion/query_expansion.py
@@ -7,7 +7,7 @@ from shepherd.query_expansion.aragorn.aragorn import expand_aragorn_query
 from shepherd.query_expansion.bte.expansion import expand_bte_query
 
 
-def expand_query(
+async def expand_query(
     query: Dict[str, Any], options: Dict[str, Any]
 ) -> tuple[List[Any], Dict[str, Any]]:
     """Get expanded queries."""

--- a/shepherd/query_expansion/query_expansion.py
+++ b/shepherd/query_expansion/query_expansion.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional, Union
 
+from shepherd.query_expansion.example.expansion import expand_example_query
 from shepherd.query_expansion.aragorn.aragorn import expand_aragorn_query
 from shepherd.query_expansion.bte.expansion import expand_bte_query
 
@@ -13,11 +14,17 @@ def expand_query(
     queries = []
     concurrency = 1
     target = options.get("target")
-    if target == "aragorn":
-        queries = expand_aragorn_query(query)
-        concurrency = 1_000_000
-    elif target == "bte":
-        queries = expand_bte_query(query)
-        concurrency = 1_000_000
+    concurrency = 1_000_000
+    match target:
+        case "example":
+            queries = expand_example_query(query)
+            # you can override template concurrency here:
+            # concurrency = 1
+        case "aragorn":
+            queries = expand_aragorn_query(query)
+        case "bte":
+            queries = expand_bte_query(query)
+        case _:
+            queries = []
 
     return queries, {"concurrency": concurrency}

--- a/shepherd/scoring/example/score.py
+++ b/shepherd/scoring/example/score.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+
+# function can be async or not
+async def example_scoring(response_body: dict[str, Any]) -> dict[str, Any]:
+    # response_body is a valid TRAPI response
+
+    # If you're interested in using reasoner-pydantic for stricter static typing,
+    # see the indented block below. Otherwise, skip to the bottom.
+
+    #    You can convert to a Response:
+
+    #    import Response from reasoner_pydantic
+    #    response = Response.parse_obj(response_body)
+
+    #    Then, when you've scored the results, you can convert it back to return:
+
+    #    return response.dict()
+
+    # Scoring must return a valid TRAPI response with all results scored.
+    # Don't do other transformations (such as trimming results/etc.), these are
+    # handled after ARA scoring.
+    # Let's pretend every result analysis was maximally good.
+    for result in response_body["message"]["results"]:
+        for analysis in result["analyses"]:
+            analysis["score"] = 1.0
+    return response_body

--- a/shepherd/scoring/example/score.py
+++ b/shepherd/scoring/example/score.py
@@ -1,4 +1,5 @@
 from typing import Any
+import random
 
 
 # function can be async or not
@@ -20,8 +21,8 @@ async def example_scoring(response_body: dict[str, Any]) -> dict[str, Any]:
     # Scoring must return a valid TRAPI response with all results scored.
     # Don't do other transformations (such as trimming results/etc.), these are
     # handled after ARA scoring.
-    # Let's pretend every result analysis was maximally good.
+    # For an example, let's make every score random.
     for result in response_body["message"]["results"]:
         for analysis in result["analyses"]:
-            analysis["score"] = 1.0
+            analysis["score"] = random.uniform(0, 1)
     return response_body

--- a/shepherd/scoring/score.py
+++ b/shepherd/scoring/score.py
@@ -15,5 +15,7 @@ async def score_query(message: Dict[str, Any], options: Dict[str, Any]) -> tuple
             response = await send_to_aragorn_ranker(message)
         case "bte":
             response = do_bte_scoring(message)
+        case _:
+            response = message
 
     return response

--- a/shepherd/scoring/score.py
+++ b/shepherd/scoring/score.py
@@ -8,9 +8,12 @@ async def score_query(message: Dict[str, Any], options: Dict[str, Any]) -> tuple
     """Score the response."""
     response = None
     target = options.get("target")
-    if target == "aragorn":
-        response = await send_to_aragorn_ranker(message)
-    elif target == "bte":
-        response = do_bte_scoring(message)
+    match target:
+        case "example":
+            response = message
+        case "aragorn":
+            response = await send_to_aragorn_ranker(message)
+        case "bte":
+            response = do_bte_scoring(message)
 
     return response

--- a/shepherd/server.py
+++ b/shepherd/server.py
@@ -62,7 +62,7 @@ async def query(
     """Handle synchronous TRAPI queries."""
     query = query.dict()
     # expand query to multiple subqueries, options
-    queries, options = expand_query(query, {"target": target})
+    queries, options = await expand_query(query, {"target": target})
     print(json.dumps(queries))
     # save query to db
     query_id, conn, pool = await add_query(query, len(queries))


### PR DESCRIPTION
Adds an example module for both expansion and scoring.

Additionally, changed expansion to support async modules, in case an ARA wants to offload expansion to another API/do other async work (similar to aragorn scoring module).