### PR TITLE
BTE expansion: use original query node IDs where appropriate

### DIFF
--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-DecreaseAnotherGeneThatUpregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-DecreaseAnotherGeneThatUpregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-IncreaseAnotherGeneThatDownregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-IncreaseAnotherGeneThatDownregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-decreasesGene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-decreasesGene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-negatively_correlated-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-negatively_correlated-Gene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:negatively_correlated_with"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-physically_interacts-GeneThatDownregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-decreases-Gene/Chem-physically_interacts-GeneThatDownregs-Gene.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:physically_interacts_with"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-DecreaseAnotherGeneThatDownregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-DecreaseAnotherGeneThatDownregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-IncreaseAnotherGeneThatUpregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-IncreaseAnotherGeneThatUpregs-Gene.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
@@ -35,7 +35,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-increasesGene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-increasesGene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:affects"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-physically_interacts-GeneThatUpregs-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-physically_interacts-GeneThatUpregs-Gene.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene", "biolink:Protein"],
                     "is_set": true
                },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:physically_interacts_with"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:regulates"],
                     "qualifier_constraints": [
                         {

--- a/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-positively_correlated-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-increases-Gene/Chem-positively_correlated-Gene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:positively_correlated_with"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Chem-physically_interacts-Gene.json
+++ b/shepherd/query_expansion/bte/templates/Chem-physically_interacts-Gene.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Gene", "biolink:Protein"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:physically_interacts_with"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-decreaseGeneWithFunctionGainIn-Disease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-decreaseGeneWithFunctionGainIn-Disease.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "qualifier_constraints": [
                         {
@@ -34,7 +34,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-increaseGeneWithFunctionLossIn-Disease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-increaseGeneWithFunctionLossIn-Disease.json
@@ -2,20 +2,20 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "qualifier_constraints": [
                         {
@@ -34,7 +34,7 @@
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-interacts,correlated,associated-Gene-biomarker,associated_condition-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-interacts,correlated,associated-Gene-biomarker,associated_condition-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:physically_interacts_with", "biolink:correlated_with", "biolink:associated_with"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": [
                         "biolink:gene_associated_with_condition",
                         "biolink:biomarker_for"

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-biomarker,associated_condition-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-biomarker,associated_condition-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:regulates", "biolink:affects"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": [
                         "biolink:gene_associated_with_condition",
                         "biolink:biomarker_for"

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-cause,contribute,affects-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-regulates,affects-Gene-cause,contribute,affects-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:regulates", "biolink:affects"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": [
                         "biolink:affects",
                         "biolink:causes",

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-causes,part-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-causes,part-DoP.json
@@ -2,26 +2,26 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:treats"]
                 },
                 "eB": {
                     "subject": "nA",
-                    "object": "on",
+                    "object": "creativeQueryObject",
                     "predicates": [
                         "biolink:part_of", 
                         "biolink:causes"

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-similar,part-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP-similar,part-DoP.json
@@ -2,25 +2,25 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:treats"]
                 },
                 "eB": {
-                    "subject": "on",
+                    "subject": "creativeQueryObject",
                     "object": "nA",
                     "predicates": [
                         "biolink:similar_to", 

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-DoP.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:treats_or_applied_or_studied_to_treat"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-PhenoOfDisease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/Chem-treats-PhenoOfDisease.json
@@ -2,25 +2,25 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 },
                 "nA": {
                     "categories":["biolink:PhenotypicFeature"],
                     "is_set": true
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
+                    "subject": "creativeQuerySubject",
                     "object": "nA",
                     "predicates": ["biolink:treats_or_applied_or_studied_to_treat"]
                 },
                 "eB": {
-                    "subject": "on",
+                    "subject": "creativeQueryObject",
                     "object": "nA",
                     "predicates": ["biolink:has_phenotype"]
                 }

--- a/shepherd/query_expansion/bte/templates/Drug-treats-Disease/ChemDecreasesLikelihood-Disease.json
+++ b/shepherd/query_expansion/bte/templates/Drug-treats-Disease/ChemDecreasesLikelihood-Disease.json
@@ -2,18 +2,18 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":
                     ["ChemicalEntity"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/NonChem-treats-DoP.json
+++ b/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/NonChem-treats-DoP.json
@@ -2,18 +2,18 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":
                     ["biolink:Procedure", "biolink:Treatment", "biolink:ClinicalIntervention"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:treats"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Procedure-decreasesLikelihood-Disease.json
+++ b/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Procedure-decreasesLikelihood-Disease.json
@@ -2,18 +2,18 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":
                     ["Procedure"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "qualifier_constraints": [
                         {
                             "qualifier_set": [

--- a/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Treatment-related_to-DoP.json
+++ b/shepherd/query_expansion/bte/templates/NonChem-treats-Disease/Treatment-related_to-DoP.json
@@ -2,17 +2,17 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:Treatment"]
                 },
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:DiseaseOrPhenotypicFeature"]
                }
             },
             "edges": {
                 "eA": {
-                    "subject": "sn",
-                    "object": "on",
+                    "subject": "creativeQuerySubject",
+                    "object": "creativeQueryObject",
                     "predicates": ["biolink:related_to"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/less-promising/m3-Disease-SeqVar-Gene-Chem.json
+++ b/shepherd/query_expansion/bte/templates/less-promising/m3-Disease-SeqVar-Gene-Chem.json
@@ -2,7 +2,7 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Disease"]
                },
                 "nA": {
@@ -13,13 +13,13 @@
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 }
             },
             "edges": {
                 "eA": {
-                    "subject": "on",
+                    "subject": "creativeQueryObject",
                     "object": "nA"
                 },
                 "eB": {
@@ -28,7 +28,7 @@
                 },
                 "eC": {
                     "subject": "nB",
-                    "object": "sn",
+                    "object": "creativeQuerySubject",
                     "predicates": ["biolink:regulated_by", "biolink:affected_by"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/less-promising/m5-Disease-Pheno-Gene-Chem.json
+++ b/shepherd/query_expansion/bte/templates/less-promising/m5-Disease-Pheno-Gene-Chem.json
@@ -2,7 +2,7 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Disease"]
                },
                 "nA": {
@@ -13,13 +13,13 @@
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 }
             },
             "edges": {
                 "eA": {
-                    "subject": "on",
+                    "subject": "creativeQueryObject",
                     "object": "nA",
                     "predicates": ["biolink:has_phenotype"]
                 },
@@ -30,7 +30,7 @@
                 },
                 "eC": {
                     "subject": "nB",
-                    "object": "sn",
+                    "object": "creativeQuerySubject",
                     "predicates": ["biolink:regulated_by", "biolink:affected_by"]
                 }
             }

--- a/shepherd/query_expansion/bte/templates/less-promising/m6-Disease-Gene-Gene-Chem.json
+++ b/shepherd/query_expansion/bte/templates/less-promising/m6-Disease-Gene-Gene-Chem.json
@@ -2,7 +2,7 @@
     "message": {
         "query_graph": {
             "nodes": {
-                "on": {
+                "creativeQueryObject": {
                     "categories":["biolink:Disease"]
                },
                 "nA": {
@@ -13,13 +13,13 @@
                     "categories":["biolink:Gene"],
                     "is_set": true
                 },
-                "sn": {
+                "creativeQuerySubject": {
                     "categories":["biolink:ChemicalEntity"]
                 }
             },
             "edges": {
                 "eA": {
-                    "subject": "on",
+                    "subject": "creativeQueryObject",
                     "object": "nA",
                     "predicates": ["biolink:caused_by"]
                 },
@@ -30,7 +30,7 @@
                 },
                 "eC": {
                     "subject": "nB",
-                    "object": "sn",
+                    "object": "creativeQuerySubject",
                     "predicates": ["biolink:regulated_by", "biolink:affected_by"]
                 }
             }


### PR DESCRIPTION
Instead of hardcoding `sn` and `on`, BTE expansion now replaces appropriate node IDs in templates with those of the original query.