### PR TITLE
Register WebSocket route under the path prefix too

### DIFF
--- a/workers/monitor/worker.py
+++ b/workers/monitor/worker.py
@@ -329,7 +329,6 @@ async def api_admin_forget_worker(name: str):
     return {"forgot": name}
 
 
-@APP.websocket("/ws")
 async def ws_endpoint(ws: WebSocket):
     await ws.accept()
     async with _clients_lock:
@@ -351,6 +350,18 @@ async def ws_endpoint(ws: WebSocket):
     finally:
         async with _clients_lock:
             _clients.discard(ws)
+
+
+# Register the WebSocket handler twice when a root_path is configured:
+#   - ``/ws``               : matches when the proxy strips the prefix (local
+#                             dev, or a future ingress that does rewrite WS).
+#   - ``{ROOT_PATH}/ws``    : matches when the proxy hands the upgrade through
+#                             with the prefix intact. Used by the separate
+#                             "no-rewrite" ingress that exists specifically so
+#                             nginx doesn't strip the WebSocket Upgrade header.
+APP.add_api_websocket_route("/ws", ws_endpoint)
+if ROOT_PATH:
+    APP.add_api_websocket_route(f"{ROOT_PATH}/ws", ws_endpoint)
 
 
 def main() -> None:


### PR DESCRIPTION
Some nginx-ingress configurations don't preserve the WebSocket ``Upgrade`` header when ``rewrite-target`` is active -- the upgrade becomes a plain HTTP GET by the time it reaches uvicorn, so the ``@APP.websocket('/ws')`` route never matches and FastAPI returns 404.

The companion fix is a separate ingress that routes ``/<prefix>/ws`` to the monitor service *without* rewrite-target, so the Upgrade headers pass through. This commit registers the WS handler at the prefixed path as well, so the route table matches regardless of whether the ingress rewrote the path.

Local dev (no MONITOR_ROOT_PATH) only adds the bare ``/ws`` entry.