### PR TITLE
Replace stdlib json with orjson in hot paths for large payloads

### DIFF
--- a/shepherd_server/aras/aragorn.py
+++ b/shepherd_server/aras/aragorn.py
@@ -36,9 +36,9 @@ async def async_query(
 @ARAGORN.post("/callback/{callback_id}", status_code=200, include_in_schema=False)
 async def handle_callback(
     callback_id: str,
-    response: dict,
+    request: Request,
 ) -> Response:
-    response = await callback(ARATargetEnum.ARAGORN, callback_id, response)
+    response = await callback(ARATargetEnum.ARAGORN, callback_id, request)
     return response
 
 

--- a/shepherd_server/aras/bte.py
+++ b/shepherd_server/aras/bte.py
@@ -36,9 +36,9 @@ async def async_query(
 @BTE.post("/callback/{callback_id}", status_code=200, include_in_schema=False)
 async def handle_callback(
     callback_id: str,
-    response: dict,
+    request: Request,
 ) -> Response:
-    response = await callback(ARATargetEnum.BTE, callback_id, response)
+    response = await callback(ARATargetEnum.BTE, callback_id, request)
     return response
 
 

--- a/shepherd_server/base_routes.py
+++ b/shepherd_server/base_routes.py
@@ -170,7 +170,10 @@ async def run_sync_query(
                 response = await get_message(response_id, logger)
                 if response is None:
                     return ORJSONResponse(
-                        content={"status": "ERROR", "description": "Unable to get response"}
+                        content={
+                            "status": "ERROR",
+                            "description": "Unable to get response",
+                        }
                     )
                 logs = await get_logs(response_id, logger)
                 response["logs"] = logs
@@ -180,9 +183,7 @@ async def run_sync_query(
         await asyncio.sleep(0.5)
 
     logger.error("Query timed out")
-    return ORJSONResponse(
-        content={"status": "TIMEOUT", "description": "Query timeout"}
-    )
+    return ORJSONResponse(content={"status": "TIMEOUT", "description": "Query timeout"})
 
 
 async def run_async_query(

--- a/shepherd_server/base_routes.py
+++ b/shepherd_server/base_routes.py
@@ -8,8 +8,9 @@ import uuid
 from enum import Enum
 from typing import Optional, Tuple
 
-from fastapi import APIRouter, Body, Response
-from fastapi.responses import JSONResponse
+import orjson
+from fastapi import APIRouter, Body, Request, Response
+from fastapi.responses import JSONResponse, ORJSONResponse
 from opentelemetry.propagate import extract, inject
 
 from shepherd_utils.broker import add_task
@@ -147,7 +148,7 @@ async def run_query(
 async def run_sync_query(
     target: ARATargetEnum,
     query: dict = Body(..., examples=[default_input_query]),
-) -> dict:
+) -> Response:
     """Handle synchronous TRAPI queries."""
     # query_dict = query.dict()
     query_dict = query
@@ -168,19 +169,20 @@ async def run_sync_query(
                 response_id = query_state[7]
                 response = await get_message(response_id, logger)
                 if response is None:
-                    return {"status": "ERROR", "description": "Unable to get response"}
+                    return ORJSONResponse(
+                        content={"status": "ERROR", "description": "Unable to get response"}
+                    )
                 logs = await get_logs(response_id, logger)
                 response["logs"] = logs
-                return response
+                return ORJSONResponse(content=response)
         else:
             logger.warning(f"Failed to get the query state of query id {query_id}")
         await asyncio.sleep(0.5)
 
     logger.error("Query timed out")
-    return {
-        "status": "TIMEOUT",
-        "description": "Query timeout",
-    }
+    return ORJSONResponse(
+        content={"status": "TIMEOUT", "description": "Query timeout"}
+    )
 
 
 async def run_async_query(
@@ -211,9 +213,16 @@ async def run_async_query(
 async def callback(
     target: ARATargetEnum,
     callback_id: str,
-    response: dict,
+    request: Request,
 ) -> Response:
     """Handle asynchronous callback queries from subservices."""
+    try:
+        response = orjson.loads(await request.body())
+    except orjson.JSONDecodeError:
+        return JSONResponse(
+            content={"detail": "Invalid JSON in request body"},
+            status_code=422,
+        )
     # Set up logger
     log_level = response.get("log_level") or "INFO"
     level_number = logging._nameToLevel[log_level]
@@ -300,7 +309,7 @@ async def get_query_response(
     logger.addHandler(log_handler)
     response = await get_message(query_id, logger)
     if response is None:
-        return 404
+        return JSONResponse(content={"error": "Not found"}, status_code=404)
     logs = await get_logs(query_id, logger)
     response["logs"] = logs
-    return response
+    return ORJSONResponse(content=response)

--- a/shepherd_utils/db.py
+++ b/shepherd_utils/db.py
@@ -236,6 +236,21 @@ async def get_message(
     return message
 
 
+async def get_message_raw(
+    message_id: str,
+    logger: logging.Logger,
+) -> bytes:
+    """Get the message from db as raw JSON bytes (no Python object parsing)."""
+    start = time.time()
+    blob = await data_db_client.get(message_id)
+    if blob is None:
+        raise KeyError(f"Failed to get {message_id} from db")
+
+    raw = zstandard.decompress(blob)
+    logger.debug(f"Getting raw message took {time.time() - start} seconds")
+    return raw
+
+
 # ---------------------------------------------------------------------------
 # Sync variants of get_message / save_message
 #

--- a/shepherd_utils/db.py
+++ b/shepherd_utils/db.py
@@ -221,34 +221,29 @@ async def save_message(
 async def get_message(
     message_id: str,
     logger: logging.Logger,
-) -> Dict:
-    """Get the message from db."""
+    raw: bool = False,
+) -> Union[Dict, bytes]:
+    """Get the message from db.
+
+    When *raw* is True, return the decompressed JSON bytes without parsing
+    into a Python object — useful when the caller will forward the payload
+    without inspecting it.
+    """
     start = time.time()
     blob = await data_db_client.get(message_id)
     if blob is None:
-        # failed to get message from db
         raise KeyError(f"Failed to get {message_id} from db")
+
+    if raw:
+        result = zstandard.decompress(blob)
+        logger.debug(f"Getting raw message took {time.time() - start} seconds")
+        return result
 
     start_decomp = time.time()
     message = decode_message(blob)
     logger.debug(f"Decompression took {time.time() - start_decomp}")
     logger.debug(f"Getting message took {time.time() - start} seconds")
     return message
-
-
-async def get_message_raw(
-    message_id: str,
-    logger: logging.Logger,
-) -> bytes:
-    """Get the message from db as raw JSON bytes (no Python object parsing)."""
-    start = time.time()
-    blob = await data_db_client.get(message_id)
-    if blob is None:
-        raise KeyError(f"Failed to get {message_id} from db")
-
-    raw = zstandard.decompress(blob)
-    logger.debug(f"Getting raw message took {time.time() - start} seconds")
-    return raw
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_finish_query.py
+++ b/tests/unit/test_finish_query.py
@@ -17,26 +17,28 @@ async def test_finish_sync_query(redis_mock, mocker):
         "workers.finish_query.worker.set_query_completed"
     )
     mock_callback_response = mocker.patch("workers.finish_query.worker.get_message")
-    mock_callback_response.return_value = orjson.dumps({
-        "message": {
-            "results": [
-                {
-                    "analyses": [
-                        {
-                            "score": 0.1,
-                        },
-                    ],
-                },
-                {
-                    "analyses": [
-                        {
-                            "score": 0.9,
-                        },
-                    ],
-                },
-            ],
-        },
-    })
+    mock_callback_response.return_value = orjson.dumps(
+        {
+            "message": {
+                "results": [
+                    {
+                        "analyses": [
+                            {
+                                "score": 0.1,
+                            },
+                        ],
+                    },
+                    {
+                        "analyses": [
+                            {
+                                "score": 0.9,
+                            },
+                        ],
+                    },
+                ],
+            },
+        }
+    )
 
     logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_finish_query.py
+++ b/tests/unit/test_finish_query.py
@@ -2,7 +2,8 @@ import json
 import logging
 import pytest
 
-from shepherd_utils.db import get_message
+import orjson
+
 from workers.finish_query.worker import finish_query
 
 
@@ -15,8 +16,8 @@ async def test_finish_sync_query(redis_mock, mocker):
     mock_set_query_completed = mocker.patch(
         "workers.finish_query.worker.set_query_completed"
     )
-    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message")
-    mock_callback_response.return_value = {
+    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message_raw")
+    mock_callback_response.return_value = orjson.dumps({
         "message": {
             "results": [
                 {
@@ -35,7 +36,7 @@ async def test_finish_sync_query(redis_mock, mocker):
                 },
             ],
         },
-    }
+    })
 
     logger = logging.getLogger(__name__)
 
@@ -75,13 +76,13 @@ async def test_finish_async_query(redis_mock, mocker):
     mock_set_query_completed = mocker.patch(
         "workers.finish_query.worker.set_query_completed"
     )
-    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message")
     final_response = {
         "message": {
             "result": "this is the final response",
         },
     }
-    mock_callback_response.return_value = final_response
+    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message_raw")
+    mock_callback_response.return_value = orjson.dumps(final_response)
 
     mock_post = mocker.patch("httpx.AsyncClient.post")
 
@@ -100,5 +101,9 @@ async def test_finish_async_query(redis_mock, mocker):
         logger,
     )
 
-    mock_post.assert_called_once_with("http://test", json=final_response)
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args.kwargs
+    assert call_kwargs["headers"]["Content-Type"] == "application/json"
+    posted_payload = orjson.loads(call_kwargs["content"])
+    assert posted_payload["message"] == final_response["message"]
     mock_set_query_completed.assert_called_once_with("test", "OK", logger)

--- a/tests/unit/test_finish_query.py
+++ b/tests/unit/test_finish_query.py
@@ -16,7 +16,7 @@ async def test_finish_sync_query(redis_mock, mocker):
     mock_set_query_completed = mocker.patch(
         "workers.finish_query.worker.set_query_completed"
     )
-    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message_raw")
+    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message")
     mock_callback_response.return_value = orjson.dumps({
         "message": {
             "results": [
@@ -81,7 +81,7 @@ async def test_finish_async_query(redis_mock, mocker):
             "result": "this is the final response",
         },
     }
-    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message_raw")
+    mock_callback_response = mocker.patch("workers.finish_query.worker.get_message")
     mock_callback_response.return_value = orjson.dumps(final_response)
 
     mock_post = mocker.patch("httpx.AsyncClient.post")

--- a/tests/unit/test_finish_query_edge_cases.py
+++ b/tests/unit/test_finish_query_edge_cases.py
@@ -5,6 +5,7 @@ existing happy-path tests don't reach.
 import json
 import logging
 
+import orjson
 import pytest
 
 from workers.finish_query.worker import finish_query
@@ -29,7 +30,7 @@ async def test_finish_query_skips_callback_when_state_missing(redis_mock, mocker
         new_callable=mocker.AsyncMock,
     )
     mock_get_message = mocker.patch(
-        "workers.finish_query.worker.get_message",
+        "workers.finish_query.worker.get_message_raw",
         new_callable=mocker.AsyncMock,
     )
     mock_post = mocker.patch("httpx.AsyncClient.post", new_callable=mocker.AsyncMock)
@@ -69,9 +70,9 @@ async def test_finish_query_propagates_status_to_set_query_completed(
         new_callable=mocker.AsyncMock,
     )
     mocker.patch(
-        "workers.finish_query.worker.get_message",
+        "workers.finish_query.worker.get_message_raw",
         new_callable=mocker.AsyncMock,
-        return_value={"message": {}},
+        return_value=orjson.dumps({"message": {}}),
     )
 
     await finish_query(
@@ -105,9 +106,9 @@ async def test_finish_async_query_retries_callback_on_failure(redis_mock, mocker
         new_callable=mocker.AsyncMock,
     )
     mocker.patch(
-        "workers.finish_query.worker.get_message",
+        "workers.finish_query.worker.get_message_raw",
         new_callable=mocker.AsyncMock,
-        return_value={"message": {"results": []}},
+        return_value=orjson.dumps({"message": {"results": []}}),
     )
     mocker.patch(
         "workers.finish_query.worker.get_logs",
@@ -153,9 +154,9 @@ async def test_finish_async_query_attaches_logs_to_message_payload(redis_mock, m
         new_callable=mocker.AsyncMock,
     )
     mocker.patch(
-        "workers.finish_query.worker.get_message",
+        "workers.finish_query.worker.get_message_raw",
         new_callable=mocker.AsyncMock,
-        return_value={"message": {"results": []}},
+        return_value=orjson.dumps({"message": {"results": []}}),
     )
     mocker.patch(
         "workers.finish_query.worker.get_logs",
@@ -185,6 +186,6 @@ async def test_finish_async_query_attaches_logs_to_message_payload(redis_mock, m
         logger,
     )
     assert mock_post.called
-    posted_payload = mock_post.call_args.kwargs["json"]
+    posted_payload = orjson.loads(mock_post.call_args.kwargs["content"])
     assert "logs" in posted_payload
     assert posted_payload["logs"][0]["message"] == "log line"

--- a/tests/unit/test_finish_query_edge_cases.py
+++ b/tests/unit/test_finish_query_edge_cases.py
@@ -30,7 +30,7 @@ async def test_finish_query_skips_callback_when_state_missing(redis_mock, mocker
         new_callable=mocker.AsyncMock,
     )
     mock_get_message = mocker.patch(
-        "workers.finish_query.worker.get_message_raw",
+        "workers.finish_query.worker.get_message",
         new_callable=mocker.AsyncMock,
     )
     mock_post = mocker.patch("httpx.AsyncClient.post", new_callable=mocker.AsyncMock)
@@ -70,7 +70,7 @@ async def test_finish_query_propagates_status_to_set_query_completed(
         new_callable=mocker.AsyncMock,
     )
     mocker.patch(
-        "workers.finish_query.worker.get_message_raw",
+        "workers.finish_query.worker.get_message",
         new_callable=mocker.AsyncMock,
         return_value=orjson.dumps({"message": {}}),
     )
@@ -106,7 +106,7 @@ async def test_finish_async_query_retries_callback_on_failure(redis_mock, mocker
         new_callable=mocker.AsyncMock,
     )
     mocker.patch(
-        "workers.finish_query.worker.get_message_raw",
+        "workers.finish_query.worker.get_message",
         new_callable=mocker.AsyncMock,
         return_value=orjson.dumps({"message": {"results": []}}),
     )
@@ -154,7 +154,7 @@ async def test_finish_async_query_attaches_logs_to_message_payload(redis_mock, m
         new_callable=mocker.AsyncMock,
     )
     mocker.patch(
-        "workers.finish_query.worker.get_message_raw",
+        "workers.finish_query.worker.get_message",
         new_callable=mocker.AsyncMock,
         return_value=orjson.dumps({"message": {"results": []}}),
     )

--- a/workers/finish_query/worker.py
+++ b/workers/finish_query/worker.py
@@ -6,12 +6,13 @@ import logging
 import time
 import uuid
 
+import orjson
 
 from shepherd_utils.broker import mark_task_as_complete
 from shepherd_utils.db import (
     cleanup_callbacks,
     get_logs,
-    get_message,
+    get_message_raw,
     get_query_state,
     set_query_completed,
 )
@@ -42,15 +43,25 @@ async def finish_query(task, logger: logging.Logger):
         callback_url = query_state[8]
         if callback_url is not None:
             # this was an async query, need to send message back
-            message = await get_message(response_id, logger)
+            message_bytes = await get_message_raw(response_id, logger)
             logs = await get_logs(response_id, logger)
-            message["logs"] = logs
+            logs_bytes = orjson.dumps(logs)
+            # Splice logs into the raw JSON bytes to avoid deserializing
+            # and re-serializing the (potentially huge) message dict.
+            if message_bytes and message_bytes[-1:] == b"}":
+                last_brace = message_bytes.rindex(b"}")
+                payload = message_bytes[:last_brace] + b',"logs":' + logs_bytes + b"}"
+            else:
+                message = orjson.loads(message_bytes)
+                message["logs"] = logs
+                payload = orjson.dumps(message)
             for attempt in range(CALLBACK_RETRIES):
                 try:
                     async with httpx.AsyncClient(timeout=120) as client:
                         response = await client.post(
                             callback_url,
-                            json=message,
+                            content=payload,
+                            headers={"Content-Type": "application/json"},
                         )
                         response.raise_for_status()
                         logger.info(f"Sent response back to {callback_url}")

--- a/workers/finish_query/worker.py
+++ b/workers/finish_query/worker.py
@@ -12,7 +12,7 @@ from shepherd_utils.broker import mark_task_as_complete
 from shepherd_utils.db import (
     cleanup_callbacks,
     get_logs,
-    get_message_raw,
+    get_message,
     get_query_state,
     set_query_completed,
 )
@@ -43,7 +43,7 @@ async def finish_query(task, logger: logging.Logger):
         callback_url = query_state[8]
         if callback_url is not None:
             # this was an async query, need to send message back
-            message_bytes = await get_message_raw(response_id, logger)
+            message_bytes = await get_message(response_id, logger, raw=True)
             logs = await get_logs(response_id, logger)
             logs_bytes = orjson.dumps(logs)
             # Splice logs into the raw JSON bytes to avoid deserializing


### PR DESCRIPTION
## Summary

- **finish_query worker**: Avoid full deserialization/reserialization of large messages by reading raw decompressed JSON bytes from Redis (`get_message_raw()`), splicing the `logs` field in at the byte level, and sending via httpx `content=` with orjson — bypassing stdlib `json.dumps` entirely
- **Sync query & `/response` endpoints**: Return `ORJSONResponse` instead of bare dicts so FastAPI uses orjson instead of stdlib `json.dumps` for response serialization
- **Callback ingest**: Parse incoming request bodies with `orjson.loads` instead of FastAPI's default stdlib `json.loads`, avoiding a wasteful stdlib-parse → orjson-reserialize round-trip
- **Bug fix**: `/response/{query_id}` was returning the integer `404` as an HTTP 200 body; now returns a proper 404 JSON response

## Context

The `finish_query` worker and synchronous query response paths were slow for large TRAPI payloads (knowledge graphs with thousands of edges). Investigation showed no pydantic models in the hot path — all data flows as plain Python dicts. The actual bottleneck was Python's stdlib `json.dumps`/`json.loads` being used where `orjson` (already a project dependency, 5-10x faster for large payloads) could be used instead. Three places fell back to stdlib json: httpx POST calls (`json=` param), FastAPI response serialization (default `JSONResponse`), and FastAPI request body parsing.

## Test plan

- [x] All 6 `finish_query` unit tests pass (updated assertions for new `content=`/`headers=` kwargs)
- [x] 201 tests pass across the full suite (6 pre-existing failures due to missing `lmdb`/`numpy`/`networkx` deps, unrelated)
- [ ] Verify large payload callback POST performance in staging
- [ ] Verify sync query response times for large knowledge graphs

https://claude.ai/code/session_01YZ9Ap96XmE8q6sQwywY5Ug

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ9Ap96XmE8q6sQwywY5Ug)_