### PR TITLE
Sort LMDB keys before batch lookups for sequential B-tree access

### DIFF
--- a/workers/aragorn_omnicorp/worker.py
+++ b/workers/aragorn_omnicorp/worker.py
@@ -348,7 +348,7 @@ def omnicorp_overlay(in_message: dict, logger: logging.Logger) -> dict:
     try:
         start_node_time = datetime.now()
 
-        keys = list(kgraph["nodes"].keys())
+        keys = sorted(kgraph["nodes"].keys())
         node_pub_counts = {}
         node_indices = {}
 
@@ -395,7 +395,7 @@ def omnicorp_overlay(in_message: dict, logger: logging.Logger) -> dict:
             return in_message
 
         keypairs = {make_key(x, node_indices): x for x in pair_to_answer.keys()}
-        inputkeys = list(keypairs.keys())
+        inputkeys = sorted(keypairs.keys())
         values = {}
 
         for batch in batches(inputkeys, LMDB_BATCH_SIZE):


### PR DESCRIPTION
## Summary

- Sort CURIE keys and shared-count index keys before batching LMDB lookups in the omnicorp overlay worker
- LMDB stores keys in sorted B-tree order, so sequential access follows the tree's page layout instead of random-seeking across pages
- Improves OS page cache hit rates for large queries where tens of thousands of lookups currently cause disk-bound random seeks

## Context

The omnicorp overlay generates O(n²) CURIE pairs for shared publication count lookups. For large queries (approaching the 100K pair threshold), random-order LMDB reads thrash the page cache, causing latency to spike from seconds to minutes. Sorting keys before lookup is a zero-risk optimization that turns random B-tree seeks into sequential scans.

## Test plan

- [x] All 8 existing `test_aragorn_omnicorp` unit tests pass
- [ ] Monitor `DEBUG_TIMING=True` logs in staging to compare pair lookup times before/after

https://claude.ai/code/session_01GaFTCrzNMRvssEaa9Qbsvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaFTCrzNMRvssEaa9Qbsvj)_