### PR TITLE
Source score_paths embeddings dir from settings config

### DIFF
--- a/shepherd_utils/config.py
+++ b/shepherd_utils/config.py
@@ -36,6 +36,8 @@ class Settings(BaseSettings):
     omnicorp_curies_lmdb_path: str = "/app/omnicorp_lmdb/curies.lmdb"
     omnicorp_shared_counts_lmdb_path: str = "/app/omnicorp_lmdb/shared_counts.lmdb"
 
+    pathfinder_embeddings_dir: str = "pathfinder_embeddings"
+
     otel_enabled: bool = True
     jaeger_host: str = "http://jaeger"
     jaeger_port: int = 4317

--- a/workers/score_paths/worker.py
+++ b/workers/score_paths/worker.py
@@ -14,6 +14,7 @@ from bmt import Toolkit
 from torch import nn
 from xgboost import XGBClassifier
 
+from shepherd_utils.config import settings
 from shepherd_utils.db import get_message_sync, save_message_sync
 from shepherd_utils.otel import setup_tracer
 from shepherd_utils.shared import get_tasks, handle_task_failure, wrap_up_task
@@ -22,7 +23,7 @@ STREAM = "score_paths"
 GROUP = "consumer"
 CONSUMER = str(uuid.uuid4())[:8]
 TASK_LIMIT = 4
-EMBEDDING_DIR = "pathfinder_embeddings"
+EMBEDDING_DIR = settings.pathfinder_embeddings_dir
 tracer = setup_tracer(STREAM)
 
 


### PR DESCRIPTION
Add a pathfinder_embeddings_dir setting to the shared Settings config so the score_paths worker reads the embeddings directory from environment variables instead of a hardcoded constant.